### PR TITLE
Add support for ARM compilers

### DIFF
--- a/ep-oc-mcu.lib
+++ b/ep-oc-mcu.lib
@@ -1,1 +1,1 @@
-https://github.com/EmbeddedPlanet/ep-oc-mcu/#ccca96d3c7f9ef9acd29479ad3bd767548595367
+https://github.com/EmbeddedPlanet/ep-oc-mcu/#9a59084da82eec2849ec803d930263eb88c51e54


### PR DESCRIPTION
Update to a newer version of [ep-oc-mcu](https://github.com/EmbeddedPlanet/ep-oc-mcu) that supports the ARM compilers (as well as GCC).

@AGlass0fMilk 