### PR TITLE
Update to latest branch of ep-oc-mcu

### DIFF
--- a/ep-oc-mcu.lib
+++ b/ep-oc-mcu.lib
@@ -1,1 +1,1 @@
-https://github.com/EmbeddedPlanet/ep-oc-mcu/#ccca96d3c7f9ef9acd29479ad3bd767548595367
+https://github.com/EmbeddedPlanet/ep-oc-mcu/#b8eac1fd7848e2982c0d0cb6ab395336572facc5


### PR DESCRIPTION
Updates to the latest version of ep-oc-mcu which has fixes for various incompatibilities between Windows/Linux, GCC/ARMC6, and Mbed OS 5/6.

@AGlass0fMilk @farrenv 